### PR TITLE
Ensure async delete dict payload returns consistent results

### DIFF
--- a/allie_sdk/core/async_handler.py
+++ b/allie_sdk/core/async_handler.py
@@ -82,12 +82,13 @@ class AsyncHandler(RequestHandler):
             requests.exceptions.HTTPError: If the API returns a non-success status code.
         """
 
+        results: list = []
         # Note: batching is implemented on a higher level since the structure of the payload is not standardised
         try:
             async_response = self.delete(
-                url = url
-                , body=payload
-                , is_async = True
+                url=url,
+                body=payload,
+                is_async=True,
             )
 
             if async_response:
@@ -98,13 +99,15 @@ class AsyncHandler(RequestHandler):
                 else:
                     # add the error details
                     # this needs to be a list here since results above is also a list
-                    results = [ async_response ]
-
-            return results
+                    results = [async_response]
+            else:
+                LOGGER.debug("No async response received from delete request")
         except requests.exceptions.HTTPError as e:
             LOGGER.error(f"HTTP error occurred: {e}", exc_info=True)
             # Raise all HTTP errors for consistent behavior
             raise
+
+        return results
 
     def async_patch(self, url: str, payload: list, batch_size: int = None) -> list:
         """Patch Alation Objects via an Async Job Process.


### PR DESCRIPTION
## Summary
- pre-initialize results list in `async_delete_dict_payload`
- always return results outside the try block
- log when async delete returns no response

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests_mock')*
- `pip install requests_mock` *(fails: Could not find a version that satisfies the requirement requests_mock)*

------
https://chatgpt.com/codex/tasks/task_b_68a5f346ea94832e83d6f2fbd4cc6d68