### PR TITLE
Add parent document field

### DIFF
--- a/allie_sdk/models/document_model.py
+++ b/allie_sdk/models/document_model.py
@@ -13,6 +13,7 @@ class DocumentBase(BaseClass):
     template_id:int = field(default = None)
     # folder_ids:list[int] = field(default = None) # DEPRECATED IN 2024.3.2
     parent_folder_id: int = field(default = None)  # ADDED IN 2024.3.2
+    parent_document_id: int = field(default = None)  # ADDED IN 2024.3.2
     nav_link_folder_ids: list[int] = field(default=None) # ADDED IN 2024.3.2
     document_hub_id:int = field(default = None)
     custom_fields:list[CustomFieldValueItem] = field(default = None)
@@ -76,6 +77,8 @@ class DocumentPostItem(DocumentBase):
             payload['parent_folder_id'] = self.parent_folder_id
         if self.nav_link_folder_ids:
             payload['nav_link_folder_ids'] = sorted(self.nav_link_folder_ids)
+        if self.parent_document_id:
+            payload['parent_document_id'] = self.parent_document_id
         if self.document_hub_id:
             payload['document_hub_id'] = self.document_hub_id
         if self.custom_fields:
@@ -116,6 +119,8 @@ class DocumentPutItem(DocumentBase):
             payload['parent_folder_id'] = self.parent_folder_id
         if self.nav_link_folder_ids:
             payload['nav_link_folder_ids'] = sorted(self.nav_link_folder_ids)
+        if self.parent_document_id:
+            payload['parent_document_id'] = self.parent_document_id
         if self.document_hub_id:
             payload['document_hub_id'] = self.document_hub_id
         if self.custom_fields:

--- a/tests/methods/test_documents.py
+++ b/tests/methods/test_documents.py
@@ -32,6 +32,7 @@ class TestDocument(unittest.TestCase):
                 "description": "Relevant data and articles for Sales Analytics",
                 "template_id": 47,
                 "parent_folder_id": 1,
+                "parent_document_id": 99,
                 "nav_link_folder_ids": [
                     14,
                     165

--- a/tests/models/test_document_model.py
+++ b/tests/models/test_document_model.py
@@ -17,6 +17,7 @@ class TestDocumentModels(unittest.TestCase):
             "description": "Relevant data and articles for Sales Analytics",
             "template_id": 47,
             "parent_folder_id": 1,
+            "parent_document_id": 99,
             "nav_link_folder_ids": [14,165],
             "document_hub_id": 1,
             "custom_fields": [
@@ -43,6 +44,7 @@ class TestDocumentModels(unittest.TestCase):
             description = "Relevant data and articles for Sales Analytics",
             template_id = 47,
             parent_folder_id = 1,
+            parent_document_id = 99,
             nav_link_folder_ids = [
                 14,
                 165
@@ -67,6 +69,7 @@ class TestDocumentModels(unittest.TestCase):
             , description = "This is the description for KPI 1"
             , template_id = 12
             , parent_folder_id = 1
+            , parent_document_id = 2
             , nav_link_folder_ids = [ 6 ]
             , document_hub_id = 2
             , custom_fields = [
@@ -91,6 +94,7 @@ class TestDocumentModels(unittest.TestCase):
             , "description": "This is the description for KPI 1"
             , "template_id": 12
             , "parent_folder_id": 1
+            , "parent_document_id": 2
             , "nav_link_folder_ids": [ 6 ]
             , "document_hub_id": 2
             , "custom_fields": [
@@ -118,6 +122,7 @@ class TestDocumentModels(unittest.TestCase):
             , description = "This is the description for KPI 1"
             , template_id = 12
             , parent_folder_id = 1
+            , parent_document_id = 2
             , nav_link_folder_ids = [ 6 ]
             , document_hub_id = 2
             , custom_fields = [
@@ -143,6 +148,7 @@ class TestDocumentModels(unittest.TestCase):
             , "description": "This is the description for KPI 1"
             , "template_id": 12
             , "parent_folder_id": 1
+            , "parent_document_id": 2
             , "nav_link_folder_ids": [ 6 ]
             , "document_hub_id": 2
             , "custom_fields": [
@@ -157,6 +163,6 @@ class TestDocumentModels(unittest.TestCase):
                 }
             ]
         }
-        
+
 
         self.assertEqual(input_transformed, output)


### PR DESCRIPTION
## Summary
- support parent_document_id for create/update Document payloads


------
https://chatgpt.com/codex/tasks/task_b_68add49a3ca0832eb81166ce3ba6e407