### PR TITLE
Add OAuth2 dataclasses

### DIFF
--- a/allie_sdk/alation.py
+++ b/allie_sdk/alation.py
@@ -30,6 +30,7 @@ from .methods import (
     , AlationVirtualFileSystem
     , AlationVirtualDataSource
     , AlationVisualConfig
+    , AlationOAuth2
 )
 
 from .models import JobDetails
@@ -155,6 +156,7 @@ class Alation(object):
         self.visual_config = AlationVisualConfig(
             access_token=self.access_token, session=session, host=host
         )
+        self.oauth2 = AlationOAuth2(session=session, host=host)
 
     @property
     def access_token(self) -> str:

--- a/allie_sdk/methods/__init__.py
+++ b/allie_sdk/methods/__init__.py
@@ -18,3 +18,4 @@ from .user import AlationUser
 from .virtual_datasource import AlationVirtualDataSource
 from .virtual_filesystem import AlationVirtualFileSystem
 from .visual_config import AlationVisualConfig
+from .oauth2 import AlationOAuth2

--- a/allie_sdk/methods/oauth2.py
+++ b/allie_sdk/methods/oauth2.py
@@ -1,0 +1,123 @@
+"""Alation OAuth 2.0 API methods."""
+
+import logging
+from dataclasses import asdict
+from urllib.parse import urlencode
+
+import requests
+
+from ..core.request_handler import RequestHandler, SUCCESS_CODES
+from ..models.oauth2_model import (
+    ActiveIntrospectTokenResponse,
+    ClientCredentialsGrantRequestPayload,
+    InactiveIntrospectTokenResponse,
+    JWKSetResponse,
+    TokenIntrospectRequestPayload,
+    TokenResponse,
+)
+
+LOGGER = logging.getLogger('allie_sdk_logger')
+
+
+class AlationOAuth2(RequestHandler):
+    """Methods for interacting with the OAuth 2.0 API v2."""
+
+    def __init__(self, session: requests.Session, host: str):
+        super().__init__(session=session, host=host)
+
+    def create_token(
+        self,
+        payload: ClientCredentialsGrantRequestPayload,
+        auth: tuple[str, str] | None = None,
+    ) -> TokenResponse:
+        """Create a JSON web token (JWT) using the client credentials grant."""
+
+        data = urlencode({k: v for k, v in asdict(payload).items() if v is not None})
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        api_response = self.s.post(
+            self.host + '/oauth/v2/token/', data=data, headers=headers, auth=auth
+        )
+
+        log_url = self._format_log_url(api_response.url)
+        log_details = {
+            'Method': 'POST',
+            'URL': api_response.url,
+            'Response': api_response.status_code,
+        }
+
+        try:
+            response_data = api_response.json()
+        except requests.exceptions.JSONDecodeError:
+            response_data = api_response.text
+
+        if api_response.status_code not in SUCCESS_CODES:
+            self._log_error(
+                response_data,
+                log_details,
+                message=f'Error submitting the POST Request to: {log_url}',
+            )
+            api_response.raise_for_status()
+
+        self._log_success(
+            log_details,
+            message=f'Successfully submitted the POST Request to: {log_url}',
+        )
+
+        return TokenResponse.from_api_response(response_data)
+
+    def introspect_token(
+        self,
+        payload: TokenIntrospectRequestPayload,
+        verify_token: bool = False,
+        auth: tuple[str, str] | None = None,
+    ):
+        """Introspect a JSON web token (JWT)."""
+
+        params = {'verify_token': str(verify_token).lower()} if verify_token else None
+        data = urlencode({k: v for k, v in asdict(payload).items() if v is not None})
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        api_response = self.s.post(
+            self.host + '/oauth/v2/introspect/',
+            data=data,
+            params=params,
+            headers=headers,
+            auth=auth,
+        )
+
+        log_url = self._format_log_url(api_response.url)
+        log_details = {
+            'Method': 'POST',
+            'URL': api_response.url,
+            'Response': api_response.status_code,
+        }
+
+        try:
+            response_data = api_response.json()
+        except requests.exceptions.JSONDecodeError:
+            response_data = api_response.text
+
+        if api_response.status_code not in SUCCESS_CODES:
+            self._log_error(
+                response_data,
+                log_details,
+                message=f'Error submitting the POST Request to: {log_url}',
+            )
+            api_response.raise_for_status()
+
+        self._log_success(
+            log_details,
+            message=f'Successfully submitted the POST Request to: {log_url}',
+        )
+
+        if response_data.get('active'):
+            return ActiveIntrospectTokenResponse.from_api_response(response_data)
+        return InactiveIntrospectTokenResponse.from_api_response(response_data)
+
+    def get_jwks(self) -> JWKSetResponse:
+        """Retrieve the JSON Web Key Set (JWKS)."""
+
+        jwks = self.get('/oauth/v2/.well-known/jwks.json/', pagination=False)
+        return JWKSetResponse.from_api_response(jwks)
+

--- a/allie_sdk/models/__init__.py
+++ b/allie_sdk/models/__init__.py
@@ -19,3 +19,4 @@ from .virtual_filesystem_model import *
 from .policy_group_model import *
 from .virtual_datasource_model import *
 from .visual_config_model import *
+from .oauth2_model import *

--- a/allie_sdk/models/oauth2_model.py
+++ b/allie_sdk/models/oauth2_model.py
@@ -1,0 +1,89 @@
+"""Alation REST API OAuth 2.0 Data Models."""
+
+from dataclasses import dataclass, field
+
+from ..core.data_structures import BaseClass
+
+
+@dataclass
+class ErrorResponse(BaseClass):
+    """Properties of an error response returned by the OAuth 2.0 API."""
+
+    error: str = field(default=None)
+    error_description: str = field(default=None)
+    code: str = field(default=None)
+
+
+@dataclass
+class TokenResponse(BaseClass):
+    """Token response containing the access token and metadata."""
+
+    access_token: str = field(default=None)
+    token_type: str = field(default=None)
+    expires_in: int = field(default=None)
+
+
+@dataclass
+class ActiveIntrospectTokenResponse(BaseClass):
+    """Response returned when a JWT is active."""
+
+    active: bool = field(default=None)
+    client_id: str = field(default=None)
+    exp: int = field(default=None)
+    iat: int = field(default=None)
+    iss: str = field(default=None)
+    jti: str = field(default=None)
+    nbf: int = field(default=None)
+    sub: str = field(default=None)
+    unique_id: str = field(default=None)
+
+
+@dataclass
+class InactiveIntrospectTokenResponse(BaseClass):
+    """Response returned when a JWT is inactive."""
+
+    active: bool = field(default=None)
+
+
+@dataclass
+class JWKResponse(BaseClass):
+    """JSON Web Key representation."""
+
+    e: str = field(default=None)
+    kid: str = field(default=None)
+    kty: str = field(default=None)
+    n: str = field(default=None)
+    use: str = field(default=None)
+
+
+@dataclass
+class JWKSetResponse(BaseClass):
+    """A set of JSON Web Keys."""
+
+    keys: list[JWKResponse] = field(default_factory=list)
+
+    def __post_init__(self):
+        if isinstance(self.keys, list):
+            self.keys = [
+                key if isinstance(key, JWKResponse) else JWKResponse.from_api_response(key)
+                for key in self.keys
+            ]
+
+
+@dataclass
+class ClientCredentialsGrantRequestPayload(BaseClass):
+    """Payload for requesting a token using the client credentials grant type."""
+
+    grant_type: str = field(default=None)
+    client_id: str = field(default=None)
+    client_secret: str = field(default=None)
+
+
+@dataclass
+class TokenIntrospectRequestPayload(BaseClass):
+    """Payload for introspecting a token."""
+
+    token: str = field(default=None)
+    token_type_hint: str = field(default=None)
+    client_id: str = field(default=None)
+    client_secret: str = field(default=None)

--- a/tests/methods/test_oauth2.py
+++ b/tests/methods/test_oauth2.py
@@ -1,0 +1,86 @@
+"""Test the OAuth 2.0 API methods."""
+
+import unittest
+
+import requests
+import requests_mock
+
+from allie_sdk.methods.oauth2 import AlationOAuth2
+from allie_sdk.models.oauth2_model import (
+    ActiveIntrospectTokenResponse,
+    ClientCredentialsGrantRequestPayload,
+    InactiveIntrospectTokenResponse,
+    JWKSetResponse,
+    TokenIntrospectRequestPayload,
+    TokenResponse,
+)
+
+
+MOCK_OAUTH2 = AlationOAuth2(session=requests.session(), host='https://test.com')
+
+
+class TestOAuth2Methods(unittest.TestCase):
+
+    @requests_mock.Mocker()
+    def test_create_token_success(self, m):
+        success_response = {
+            "access_token": "abc",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+        m.register_uri('POST', '/oauth/v2/token/', json=success_response)
+        payload = ClientCredentialsGrantRequestPayload(grant_type='client_credentials')
+        token = MOCK_OAUTH2.create_token(payload)
+        expected = TokenResponse.from_api_response(success_response)
+        self.assertEqual(token, expected)
+
+    @requests_mock.Mocker()
+    def test_create_token_failure(self, m):
+        error_response = {"error": "invalid_client"}
+        m.register_uri('POST', '/oauth/v2/token/', json=error_response, status_code=401)
+        payload = ClientCredentialsGrantRequestPayload(grant_type='client_credentials')
+        with self.assertRaises(requests.exceptions.HTTPError):
+            MOCK_OAUTH2.create_token(payload)
+
+    @requests_mock.Mocker()
+    def test_introspect_token_active(self, m):
+        active_response = {"active": True, "exp": 1, "iat": 1, "jti": "id", "nbf": 1}
+        m.register_uri('POST', '/oauth/v2/introspect/', json=active_response)
+        payload = TokenIntrospectRequestPayload(token='token')
+        result = MOCK_OAUTH2.introspect_token(payload)
+        expected = ActiveIntrospectTokenResponse.from_api_response(active_response)
+        self.assertEqual(result, expected)
+
+    @requests_mock.Mocker()
+    def test_introspect_token_inactive(self, m):
+        inactive_response = {"active": False}
+        m.register_uri('POST', '/oauth/v2/introspect/', json=inactive_response)
+        payload = TokenIntrospectRequestPayload(token='token')
+        result = MOCK_OAUTH2.introspect_token(payload)
+        expected = InactiveIntrospectTokenResponse.from_api_response(inactive_response)
+        self.assertEqual(result, expected)
+
+    @requests_mock.Mocker()
+    def test_introspect_token_failure(self, m):
+        error_response = {"error": "invalid_client"}
+        m.register_uri('POST', '/oauth/v2/introspect/', json=error_response, status_code=401)
+        payload = TokenIntrospectRequestPayload(token='token')
+        with self.assertRaises(requests.exceptions.HTTPError):
+            MOCK_OAUTH2.introspect_token(payload)
+
+    @requests_mock.Mocker()
+    def test_get_jwks(self, m):
+        jwk_set = {
+            "keys": [
+                {"e": "AQAB", "kid": "1", "kty": "sig", "n": "mod", "use": "sig"}
+            ]
+        }
+        m.register_uri('GET', '/oauth/v2/.well-known/jwks.json/', json=jwk_set)
+        result = MOCK_OAUTH2.get_jwks()
+        expected = JWKSetResponse.from_api_response(jwk_set)
+        self.assertEqual(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/models/test_oauth2_model.py
+++ b/tests/models/test_oauth2_model.py
@@ -1,0 +1,117 @@
+"""Test the OAuth 2.0 API V2 data models."""
+
+import unittest
+
+from allie_sdk.models.oauth2_model import (
+    TokenResponse,
+    ActiveIntrospectTokenResponse,
+    InactiveIntrospectTokenResponse,
+    JWKResponse,
+    JWKSetResponse,
+    ClientCredentialsGrantRequestPayload,
+    TokenIntrospectRequestPayload,
+    ErrorResponse,
+)
+
+
+class TestOAuth2Models(unittest.TestCase):
+
+    def test_token_response_model(self):
+        response = {
+            "access_token": "2YotnFZFEjr1zCsicMWpAA",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+        token = TokenResponse.from_api_response(response)
+        expected = TokenResponse(
+            access_token="2YotnFZFEjr1zCsicMWpAA",
+            token_type="Bearer",
+            expires_in=3600,
+        )
+        self.assertEqual(token, expected)
+
+    def test_active_introspect_token_response_model(self):
+        response = {
+            "active": True,
+            "client_id": "4e0dfdf0-1a77-41e5-9d7b-4cab6d926e02",
+            "exp": 1643791003,
+            "iat": 1643791003,
+            "iss": "https://example.com",
+            "jti": "f6a3a277-5006-4e35-84a6-ead3c2efe726",
+            "nbf": 1643791003,
+            "sub": "example@example.com",
+            "unique_id": "f6a3a277-5006-4e35-84a6-ead3c2efe726",
+        }
+        introspection = ActiveIntrospectTokenResponse.from_api_response(response)
+        expected = ActiveIntrospectTokenResponse(
+            active=True,
+            client_id="4e0dfdf0-1a77-41e5-9d7b-4cab6d926e02",
+            exp=1643791003,
+            iat=1643791003,
+            iss="https://example.com",
+            jti="f6a3a277-5006-4e35-84a6-ead3c2efe726",
+            nbf=1643791003,
+            sub="example@example.com",
+            unique_id="f6a3a277-5006-4e35-84a6-ead3c2efe726",
+        )
+        self.assertEqual(introspection, expected)
+
+    def test_inactive_introspect_token_response_model(self):
+        response = {"active": False}
+        introspection = InactiveIntrospectTokenResponse.from_api_response(response)
+        expected = InactiveIntrospectTokenResponse(active=False)
+        self.assertEqual(introspection, expected)
+
+    def test_jwk_set_response_model(self):
+        response = {
+            "keys": [
+                {
+                    "e": "AQAB",
+                    "kid": "1",
+                    "kty": "sig",
+                    "n": "modulus",
+                    "use": "sig",
+                }
+            ]
+        }
+        jwk_set = JWKSetResponse.from_api_response(response)
+        expected = JWKSetResponse(
+            keys=[
+                JWKResponse(e="AQAB", kid="1", kty="sig", n="modulus", use="sig")
+            ]
+        )
+        self.assertEqual(jwk_set, expected)
+
+    def test_request_payload_models(self):
+        token_request = ClientCredentialsGrantRequestPayload(
+            grant_type="client_credentials",
+            client_id="s6BhdRkqt3",
+            client_secret="P@s$w0rd!",
+        )
+        self.assertEqual(token_request.grant_type, "client_credentials")
+
+        introspect_request = TokenIntrospectRequestPayload(
+            token="token",
+            token_type_hint="access_token",
+            client_id="client",
+            client_secret="secret",
+        )
+        self.assertEqual(introspect_request.token_type_hint, "access_token")
+
+    def test_error_response_model(self):
+        response = {
+            "error": "invalid_client",
+            "error_description": "Client credentials might be incorrect or client not found.",
+            "code": "401",
+        }
+        error = ErrorResponse.from_api_response(response)
+        expected = ErrorResponse(
+            error="invalid_client",
+            error_description="Client credentials might be incorrect or client not found.",
+            code="401",
+        )
+        self.assertEqual(error, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add data models for OAuth 2.0 API v2 including token, introspection, JWK and error payloads
- expose OAuth 2.0 models via package init
- cover new models with unit tests
- implement OAuth2 API methods for token creation, token introspection and JWKS retrieval
- expose OAuth2 methods through the methods package and main Alation client
- add unit tests for OAuth2 methods

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement requests_mock)*
- `pytest tests/models/test_oauth2_model.py`
- `pytest tests/methods/test_oauth2.py` *(fails: ModuleNotFoundError: No module named 'requests_mock')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests_mock')*


------
https://chatgpt.com/codex/tasks/task_b_68b81636032c832e841e171e5de44d29