### PR TITLE
Add dataflow endpoint classes and tests

### DIFF
--- a/allie_sdk/methods/__init__.py
+++ b/allie_sdk/methods/__init__.py
@@ -5,6 +5,7 @@ from .custom_field import AlationCustomField
 from .custom_template import AlationCustomTemplate
 from .data_quality import AlationDataQuality
 from .datasource import AlationDatasource
+from .dataflow import AlationDataflow
 from .document import AlationDocument
 from .document_hub_folder import AlationDocumentHubFolder
 from .domain import AlationDomain

--- a/allie_sdk/methods/dataflow.py
+++ b/allie_sdk/methods/dataflow.py
@@ -1,0 +1,56 @@
+import logging
+import requests
+
+from ..core.async_handler import AsyncHandler
+from ..core.custom_exceptions import validate_query_params, validate_rest_payload
+from ..models.dataflow_model import Dataflow, DataflowPatchItem, DataflowPayload, DataflowParams
+from ..models.job_model import JobDetails
+
+LOGGER = logging.getLogger('allie_sdk_logger')
+
+
+class AlationDataflow(AsyncHandler):
+    """Alation REST API Dataflow Methods."""
+
+    def __init__(self, access_token: str, session: requests.Session, host: str):
+        """Creates an instance of the Dataflow object."""
+        super().__init__(session=session, host=host, access_token=access_token)
+
+    def get_dataflows(self, query_params: DataflowParams = None) -> DataflowPayload:
+        """Retrieve dataflow objects and their paths."""
+        validate_query_params(query_params, DataflowParams)
+        params = query_params.generate_params_dict() if query_params else None
+        data = self.get('/integration/v2/dataflow/', query_params=params, pagination=False)
+        if data:
+            return DataflowPayload.from_api_response(data)
+        return DataflowPayload()
+
+    def create_or_replace_dataflows(self, payload: DataflowPayload) -> list[JobDetails]:
+        """Create or replace dataflow objects with lineage paths."""
+        if payload is None:
+            return []
+        validate_rest_payload([payload], (DataflowPayload,))
+        payload_dict = payload.generate_api_post_payload()
+        async_results = self.async_post_dict_payload('/integration/v2/dataflow/', payload_dict)
+        if async_results:
+            return [JobDetails.from_api_response(item) for item in async_results]
+        return []
+
+    def update_dataflows(self, dataflows: list[DataflowPatchItem]) -> list[JobDetails]:
+        """Update multiple dataflow objects."""
+        item: DataflowPatchItem
+        validate_rest_payload(dataflows, (DataflowPatchItem,))
+        payload = [item.generate_api_patch_payload() for item in dataflows]
+        async_results = self.async_patch('/integration/v2/dataflow/', payload=payload)
+        if async_results:
+            return [JobDetails.from_api_response(item) for item in async_results]
+        return []
+
+    def delete_dataflows(self, object_ids: list[int | str]) -> list[JobDetails]:
+        """Delete multiple dataflow objects."""
+        if not object_ids:
+            return []
+        async_results = self.async_delete('/integration/v2/dataflow/', payload=object_ids)
+        if async_results:
+            return [JobDetails.from_api_response(item) for item in async_results]
+        return []

--- a/allie_sdk/models/__init__.py
+++ b/allie_sdk/models/__init__.py
@@ -4,6 +4,7 @@ from .connector_model import *
 from .custom_field_model import *
 from .custom_template_model import *
 from .data_quality_model import *
+from .dataflow_model import *
 from .document_hub_folder_model import *
 from .datasource_model import *
 from .document_model import *

--- a/allie_sdk/models/dataflow_model.py
+++ b/allie_sdk/models/dataflow_model.py
@@ -1,0 +1,124 @@
+"""Alation REST API Dataflow Data Models."""
+
+from dataclasses import dataclass, field
+from ..core.data_structures import BaseClass, BaseParams
+from ..core.custom_exceptions import validate_rest_payload, InvalidPostBody
+
+
+@dataclass(kw_only=True)
+class DataflowBase(BaseClass):
+    """Common properties for Dataflow objects."""
+    title: str = field(default=None)
+    description: str = field(default=None)
+    content: str = field(default=None)
+    group_name: str = field(default=None)
+
+
+@dataclass(kw_only=True)
+class Dataflow(DataflowBase):
+    """Dataflow object definition."""
+    external_id: str = field(default=None)
+    id: int = field(default=None)
+
+    def generate_api_post_payload(self) -> dict:
+        if self.external_id is None:
+            raise InvalidPostBody("'external_id' is a required field for Dataflow POST payload body")
+        payload = {"external_id": self.external_id}
+        if self.title:
+            payload["title"] = self.title
+        if self.description:
+            payload["description"] = self.description
+        if self.content:
+            payload["content"] = self.content
+        if self.group_name:
+            payload["group_name"] = self.group_name
+        return payload
+
+
+@dataclass(kw_only=True)
+class DataflowPatchItem(DataflowBase):
+    """Dataflow object definition for PATCH requests."""
+    id: int
+
+    def generate_api_patch_payload(self) -> dict:
+        if self.id is None:
+            raise InvalidPostBody("'id' is a required field for Dataflow PATCH payload body")
+        payload = {"id": self.id}
+        if self.title:
+            payload["title"] = self.title
+        if self.description:
+            payload["description"] = self.description
+        if self.content:
+            payload["content"] = self.content
+        if self.group_name:
+            payload["group_name"] = self.group_name
+        return payload
+
+
+@dataclass(kw_only=True)
+class DataflowPathObject(BaseClass):
+    """Single object within a Dataflow path segment."""
+    otype: str = field(default=None)
+    key: str = field(default=None)
+
+    def generate_api_payload(self) -> dict:
+        if self.otype is None or self.key is None:
+            raise InvalidPostBody("'otype' and 'key' are required fields for Dataflow path object")
+        return {"otype": self.otype, "key": self.key}
+
+
+@dataclass(kw_only=True)
+class DataflowPayload(BaseClass):
+    """Payload for Dataflow POST requests."""
+    dataflow_objects: list[Dataflow] = field(default_factory=list)
+    paths: list[list[list[DataflowPathObject]]] = field(default_factory=list)
+
+    def __post_init__(self):
+        if isinstance(self.dataflow_objects, list):
+            self.dataflow_objects = [
+                Dataflow.from_api_response(value) if isinstance(value, dict) else value
+                for value in self.dataflow_objects
+            ]
+        if isinstance(self.paths, list):
+            paths_out = []
+            for path in self.paths:
+                path_out = []
+                if isinstance(path, list):
+                    for segment in path:
+                        if isinstance(segment, list):
+                            segment_out = []
+                            validate_rest_payload(segment, (DataflowPathObject,))
+                            for obj in segment:
+                                if isinstance(obj, dict):
+                                    segment_out.append(DataflowPathObject.from_api_response(obj))
+                                else:
+                                    segment_out.append(obj)
+                            path_out.append(segment_out)
+                paths_out.append(path_out)
+            self.paths = paths_out
+
+    def generate_api_post_payload(self) -> dict:
+        payload: dict = {}
+        if self.dataflow_objects:
+            validate_rest_payload(self.dataflow_objects, (Dataflow,))
+            payload["dataflow_objects"] = [
+                item.generate_api_post_payload() for item in self.dataflow_objects
+            ]
+        if self.paths:
+            paths_payload = []
+            for path in self.paths:
+                path_payload = []
+                for segment in path:
+                    validate_rest_payload(segment, (DataflowPathObject,))
+                    path_payload.append([obj.generate_api_payload() for obj in segment])
+                paths_payload.append(path_payload)
+            payload["paths"] = paths_payload
+        return payload
+
+
+@dataclass(kw_only=True)
+class DataflowParams(BaseParams):
+    """Query parameters for Dataflow GET requests."""
+    keyField: str = field(default=None)
+    limit: int = field(default=None)
+    skip: int = field(default=None)

--- a/tests/methods/test_dataflow.py
+++ b/tests/methods/test_dataflow.py
@@ -1,0 +1,125 @@
+"""Test the Alation REST API Dataflow Methods."""
+
+import requests_mock
+import unittest
+from allie_sdk.methods.dataflow import *
+
+
+class TestDataflow(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_df = AlationDataflow(
+            access_token='test',
+            session=requests.session(),
+            host='https://test.com'
+        )
+
+    @requests_mock.Mocker()
+    def test_get_dataflows(self, requests_mock):
+        api_response = {
+            "dataflow_objects": [
+                {
+                    "id": 1,
+                    "external_id": "api/df101",
+                    "title": "Purchase transaction Transformation",
+                    "description": "Data flow from customer table to purchase history table",
+                    "content": "select * from table",
+                    "group_name": "Snowflake-1"
+                }
+            ],
+            "paths": [
+                [
+                    [{"otype": "table", "key": "1.schema.Customers"}],
+                    [{"otype": "dataflow", "key": "api/df101"}],
+                    [{"otype": "table", "key": "1.schema.Purchases"}],
+                ]
+            ]
+        }
+
+        expected = DataflowPayload.from_api_response(api_response)
+
+        requests_mock.register_uri(
+            method='GET',
+            url='/integration/v2/dataflow/',
+            json=api_response,
+            status_code=200
+        )
+
+        result = self.mock_df.get_dataflows()
+        self.assertEqual(result, expected)
+
+    @requests_mock.Mocker()
+    def test_create_or_replace_dataflows(self, requests_mock):
+        post_response = {"job_id": 100}
+        job_response = {
+            "status": "successful",
+            "msg": "",
+            "result": None
+        }
+        requests_mock.register_uri(
+            method='POST',
+            url='/integration/v2/dataflow/',
+            json=post_response,
+            status_code=202
+        )
+        requests_mock.register_uri(
+            method='GET',
+            url='/api/v1/bulk_metadata/job/?id=100',
+            json=job_response,
+            status_code=200
+        )
+        payload = DataflowPayload(
+            dataflow_objects=[Dataflow(external_id="api/df101")]
+        )
+        result = self.mock_df.create_or_replace_dataflows(payload)
+        expected = [JobDetails.from_api_response(job_response)]
+        self.assertEqual(result, expected)
+
+    @requests_mock.Mocker()
+    def test_update_dataflows(self, requests_mock):
+        patch_response = {"job_id": 101}
+        job_response = {
+            "status": "successful",
+            "msg": "",
+            "result": None
+        }
+        requests_mock.register_uri(
+            method='PATCH',
+            url='/integration/v2/dataflow/',
+            json=patch_response,
+            status_code=202
+        )
+        requests_mock.register_uri(
+            method='GET',
+            url='/api/v1/bulk_metadata/job/?id=101',
+            json=job_response,
+            status_code=200
+        )
+        items = [DataflowPatchItem(id=1, title="New")] 
+        result = self.mock_df.update_dataflows(items)
+        expected = [JobDetails.from_api_response(job_response)]
+        self.assertEqual(result, expected)
+
+    @requests_mock.Mocker()
+    def test_delete_dataflows(self, requests_mock):
+        delete_response = {"job_id": 102}
+        job_response = {
+            "status": "successful",
+            "msg": "",
+            "result": None
+        }
+        requests_mock.register_uri(
+            method='DELETE',
+            url='/integration/v2/dataflow/',
+            json=delete_response,
+            status_code=202
+        )
+        requests_mock.register_uri(
+            method='GET',
+            url='/api/v1/bulk_metadata/job/?id=102',
+            json=job_response,
+            status_code=200
+        )
+        result = self.mock_df.delete_dataflows([1])
+        expected = [JobDetails.from_api_response(job_response)]
+        self.assertEqual(result, expected)

--- a/tests/models/test_dataflow_model.py
+++ b/tests/models/test_dataflow_model.py
@@ -1,0 +1,88 @@
+import unittest
+from allie_sdk.models.dataflow_model import *
+
+
+class TestDataflowModels(unittest.TestCase):
+
+    def test_dataflow_model(self):
+        input_dict = {
+            "id": 1,
+            "external_id": "api/df101",
+            "title": "Purchase transaction Transformation",
+            "description": "Data flow from customer table to purchase history table",
+            "content": "select * from table",
+            "group_name": "Snowflake-1"
+        }
+
+        input_transformed = Dataflow(**input_dict)
+
+        output = Dataflow(
+            id=1,
+            external_id="api/df101",
+            title="Purchase transaction Transformation",
+            description="Data flow from customer table to purchase history table",
+            content="select * from table",
+            group_name="Snowflake-1"
+        )
+
+        self.assertEqual(input_transformed, output)
+
+    def test_dataflow_payload_post(self):
+        payload_obj = DataflowPayload(
+            dataflow_objects=[
+                Dataflow(
+                    external_id="api/df101",
+                    title="Purchase transaction Transformation",
+                    description="Data flow from customer table to purchase history table",
+                    content="select c.id from customers c",
+                    group_name="Snowflake-1",
+                )
+            ],
+            paths=[
+                [
+                    [DataflowPathObject(otype="table", key="1.schema.Customers")],
+                    [DataflowPathObject(otype="dataflow", key="api/df101")],
+                    [DataflowPathObject(otype="table", key="1.schema.Purchases")],
+                ]
+            ],
+        )
+
+        expected = {
+            "dataflow_objects": [
+                {
+                    "external_id": "api/df101",
+                    "title": "Purchase transaction Transformation",
+                    "description": "Data flow from customer table to purchase history table",
+                    "content": "select c.id from customers c",
+                    "group_name": "Snowflake-1",
+                }
+            ],
+            "paths": [
+                [
+                    [{"otype": "table", "key": "1.schema.Customers"}],
+                    [{"otype": "dataflow", "key": "api/df101"}],
+                    [{"otype": "table", "key": "1.schema.Purchases"}],
+                ]
+            ],
+        }
+
+        self.assertEqual(payload_obj.generate_api_post_payload(), expected)
+
+    def test_dataflow_patch_item(self):
+        item = DataflowPatchItem(
+            id=1,
+            title="New title",
+            description="New description",
+            content="select *",
+            group_name="Group",
+        )
+
+        expected = {
+            "id": 1,
+            "title": "New title",
+            "description": "New description",
+            "content": "select *",
+            "group_name": "Group",
+        }
+
+        self.assertEqual(item.generate_api_patch_payload(), expected)


### PR DESCRIPTION
## Summary
- implement dataflow dataclasses and payload builders
- add AlationDataflow methods for get, create, update and delete operations
- cover dataflow models and methods with unit tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests_mock')*


------
https://chatgpt.com/codex/tasks/task_b_68b877f7053c8324b8e054c634f524a9