### PR TITLE
Fix error detail check in request handler

### DIFF
--- a/allie_sdk/core/request_handler.py
+++ b/allie_sdk/core/request_handler.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import requests
-import json
 
 from urllib.parse import urlparse
 from requests.adapters import HTTPAdapter, Retry
@@ -423,7 +422,7 @@ class RequestHandler(object):
                 # we just simply dump the output here
                 message = f'{message}\nERRORS: {json.dumps(error_errors)}'
 
-            if all(var is None for var in (error_code, error_title, error_title)):
+            if all(var is None for var in (error_code, error_title, error_detail)):
                 details['Error'] = response_data
                 message = f'{message}\nERROR: {response_data}'
 


### PR DESCRIPTION
## Summary
- remove duplicate JSON import
- fix error logging to consider error detail instead of repeating error title

## Testing
- `pytest tests/models`
- `pytest tests/core/test_request_handler.py` *(fails: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_b_68c2818a3638832e87a808d70736a0d5