### PR TITLE
Add column patch support

### DIFF
--- a/allie_sdk/__init__.py
+++ b/allie_sdk/__init__.py
@@ -10,6 +10,7 @@ from .models import (
     Column,
     ColumnIndex,
     ColumnItem,
+    ColumnPatchItem,
     ColumnParams,
     Connector,
     CustomField,

--- a/allie_sdk/methods/rdbms.py
+++ b/allie_sdk/methods/rdbms.py
@@ -8,7 +8,7 @@ from ..core.custom_exceptions import validate_query_params, validate_rest_payloa
 from ..models.rdbms_model import (
     Schema, SchemaItem, SchemaParams,
     Table, TableItem, TableParams,
-    Column, ColumnItem, ColumnParams
+    Column, ColumnItem, ColumnPatchItem, ColumnParams
 )
 from ..models.job_model import *
 
@@ -138,6 +138,28 @@ class AlationRDBMS(AsyncHandler):
         except requests.exceptions.HTTPError:
             # Re-raise the error
             raise
+
+    def patch_columns(self, ds_id: int, columns: list) -> list[JobDetailsRdbms]:
+        """Patch (Update) Alation Column Objects.
+
+        Args:
+            ds_id (int): ID of the Alation Columns' Parent Datasource.
+            columns (list): Alation Columns to be updated.
+
+        Returns:
+            list[JobDetailsRdbms]: result of the job
+
+        Raises:
+            requests.HTTPError: If the API returns a non-success status code.
+        """
+        item: ColumnPatchItem
+        validate_rest_payload(columns, (ColumnPatchItem,))
+        payload = [item.generate_api_patch_payload() for item in columns]
+        async_results = self.async_patch(f'/integration/v2/column/?ds_id={ds_id}', payload)
+
+        if async_results:
+            return [JobDetailsRdbms.from_api_response(item) for item in async_results]
+        return []
 
     def post_columns(self, ds_id: int, columns: list) -> list[JobDetailsRdbms]:
         """Post (Create or Update) Alation Column Objects.

--- a/allie_sdk/methods/rdbms.py
+++ b/allie_sdk/methods/rdbms.py
@@ -139,7 +139,7 @@ class AlationRDBMS(AsyncHandler):
             # Re-raise the error
             raise
 
-    def patch_columns(self, ds_id: int, columns: list) -> list[JobDetailsRdbms]:
+    def patch_columns(self, ds_id: int, columns: list[ColumnPatchItem]) -> list[JobDetailsRdbms]:
         """Patch (Update) Alation Column Objects.
 
         Args:

--- a/allie_sdk/methods/rdbms.py
+++ b/allie_sdk/methods/rdbms.py
@@ -8,7 +8,7 @@ from ..core.custom_exceptions import validate_query_params, validate_rest_payloa
 from ..models.rdbms_model import (
     Schema, SchemaItem, SchemaParams,
     Table, TableItem, TableParams,
-    Column, ColumnItem, ColumnPatchItem, ColumnParams
+    Column, ColumnItem, ColumnIndex, ColumnPatchItem, ColumnParams
 )
 from ..models.job_model import *
 

--- a/allie_sdk/models/document_model.py
+++ b/allie_sdk/models/document_model.py
@@ -44,7 +44,7 @@ class Document(DocumentBase):
 @dataclass(kw_only = True)
 class DocumentPostItem(DocumentBase):
 
-    # OPEN: MOVE OUTSIDE, duplicate
+    # TODO: MOVE OUTSIDE, duplicate
     def _create_fields_payload(self) -> list:
         item: CustomFieldValueItem
         validate_rest_payload(self.custom_fields, (CustomFieldValueItem,))
@@ -87,7 +87,7 @@ class DocumentPostItem(DocumentBase):
 class DocumentPutItem(DocumentBase):
     id:int # mandatory
 
-    # OPEN: MOVE OUTSIDE, duplicate
+    # TODO: MOVE OUTSIDE, duplicate
     def _create_fields_payload(self) -> list:
         item: CustomFieldValueItem
         validate_rest_payload(self.custom_fields, (CustomFieldValueItem,))

--- a/allie_sdk/models/job_model.py
+++ b/allie_sdk/models/job_model.py
@@ -191,7 +191,7 @@ class JobDetailsRdbmsResultMapping(BaseClass):
 @dataclass(kw_only = True)
 class JobDetailsRdbmsResult(BaseClass):
     response: str = field(default = None)
-    mapping: list[dict] = field(default_factory = list)
+    mapping: list[JobDetailsRdbmsResultMapping] = field(default_factory = list)
     errors: list = field(default_factory = list)
     def __post_init__(self):
         # Make sure the nested result gets converted to the proper data class

--- a/allie_sdk/models/rdbms_model.py
+++ b/allie_sdk/models/rdbms_model.py
@@ -154,12 +154,25 @@ class TableParams(BaseRDBMSParams):
     schema_name__iendswith: set = field(default_factory=set)
 
 
-@dataclass
+@dataclass(kw_only = True)
 class ColumnIndex(BaseClass):
     isPrimaryKey: bool = field(default=None)
     isForeignKey: bool = field(default=None)
     referencedColumnId: str = field(default=None)
     isOtherIndex: bool = field(default=None)
+
+    def generate_api_post_payload(self):
+        payload = {}
+        if self.isPrimaryKey is not None:
+            payload['isPrimaryKey'] = self.isPrimaryKey
+        if self.isForeignKey is not None:
+            payload['isForeignKey'] = self.isForeignKey
+        if self.referencedColumnId:
+            payload['referencedColumnId'] = self.referencedColumnId
+        if self.isOtherIndex is not None:
+            payload['isOtherIndex'] = self.isOtherIndex
+
+        return payload
 
 @dataclass
 class Column(BaseRDBMS):
@@ -204,15 +217,7 @@ class ColumnItem(BaseRDBMSItem):
         if self.position:
             payload['position'] = self.position
         if self.index:
-            payload['index'] = {}
-            if self.index.isPrimaryKey is not None:
-                payload['index']['isPrimaryKey'] = self.index.isPrimaryKey
-            if self.index.isForeignKey is not None:
-                payload['index']['isForeignKey'] = self.index.isForeignKey
-            if self.index.isOtherIndex is not None:
-                payload['index']['isOtherIndex'] = self.index.isOtherIndex
-            if self.index.referencedColumnId:
-                payload['index']['referencedColumnId'] = self.index.referencedColumnId
+            payload['index'] = ColumnIndex.generate_api_post_payload(self.index)
         if self.custom_fields:
             payload['custom_fields'] = self._create_fields_payload()
 
@@ -242,15 +247,7 @@ class ColumnPatchItem(BaseRDBMSItem):
         if self.position:
             payload['position'] = self.position
         if self.index:
-            payload['index'] = {}
-            if self.index.isPrimaryKey is not None:
-                payload['index']['isPrimaryKey'] = self.index.isPrimaryKey
-            if self.index.isForeignKey is not None:
-                payload['index']['isForeignKey'] = self.index.isForeignKey
-            if self.index.isOtherIndex is not None:
-                payload['index']['isOtherIndex'] = self.index.isOtherIndex
-            if self.index.referencedColumnId:
-                payload['index']['referencedColumnId'] = self.index.referencedColumnId
+            payload['index'] = ColumnIndex.generate_api_post_payload(self.index)
         if self.custom_fields:
             payload['custom_fields'] = self._create_fields_payload()
 

--- a/allie_sdk/models/rdbms_model.py
+++ b/allie_sdk/models/rdbms_model.py
@@ -218,6 +218,44 @@ class ColumnItem(BaseRDBMSItem):
 
         return payload
 
+
+@dataclass
+class ColumnPatchItem(BaseRDBMSItem):
+    id: int = field(default=None)
+    column_comment: str = field(default=None)
+    nullable: bool = field(default=None)
+    position: int = field(default=None)
+    index: ColumnIndex = field(default=None)
+
+    def generate_api_patch_payload(self):
+        if self.id is None:
+            raise InvalidPostBody("'id' is a required field for Column PATCH payload body")
+        payload = {'id': self.id}
+        if self.title:
+            payload['title'] = self.title
+        if self.description:
+            payload['description'] = self.description
+        if self.column_comment:
+            payload['column_comment'] = self.column_comment
+        if self.nullable is not None:
+            payload['nullable'] = self.nullable
+        if self.position:
+            payload['position'] = self.position
+        if self.index:
+            payload['index'] = {}
+            if self.index.isPrimaryKey is not None:
+                payload['index']['isPrimaryKey'] = self.index.isPrimaryKey
+            if self.index.isForeignKey is not None:
+                payload['index']['isForeignKey'] = self.index.isForeignKey
+            if self.index.isOtherIndex is not None:
+                payload['index']['isOtherIndex'] = self.index.isOtherIndex
+            if self.index.referencedColumnId:
+                payload['index']['referencedColumnId'] = self.index.referencedColumnId
+        if self.custom_fields:
+            payload['custom_fields'] = self._create_fields_payload()
+
+        return payload
+
 @dataclass
 class ColumnParams(BaseRDBMSParams):
     table_id: set = field(default_factory=set)

--- a/docs/pages/reference/RDBMS.md
+++ b/docs/pages/reference/RDBMS.md
@@ -308,6 +308,23 @@ Args:
 Returns:
 * list of job details
 
+### patch_columns
+
+```python
+patch_columns(ds_id: int, columns: list[ColumnPatchItem]) -> list[allie_sdk.models.job_model.JobDetailsRdbms]
+```
+
+Patch (Update) Alation Column Objects.
+
+Args:
+   - `ds_id` (int): ID of the Alation Columns' Parent Datasource.
+   - `columns` (list): Alation Columns to be updated.
+
+Returns:
+   - `list[JobDetailsRdbms]`: result of the job
+
+Raises:
+   - `requests.HTTPError`: If the API returns a non-success status code.
 
 ## Examples
 

--- a/examples/example_rdbms.py
+++ b/examples/example_rdbms.py
@@ -21,7 +21,7 @@ from allie_sdk import JobDetailsRdbmsResult
 # ================================
 
 # adjust to your requirements
-DATA_SOURCE_ID = 3
+DATA_SOURCE_ID = 1
 
 # ================================
 # Define Logging Config

--- a/examples/example_rdbms.py
+++ b/examples/example_rdbms.py
@@ -118,35 +118,6 @@ else:
         logging.error("Unexpected result ... I don't know how to handle this ...")
         sys.exit(1)
 
-# ================================
-# UPDATE COLUMN WITH PATCH
-# ================================
-
-patch_column_response = alation.rdbms.patch_columns(
-    ds_id = DATA_SOURCE_ID,
-    columns = [
-        allie.ColumnPatchItem(
-            id = created_column_id,
-            title = "ID",
-            description = "Updated description for the id column ..."
-        )
-    ]
-)
-
-if patch_column_response is None:
-    logging.error("Tried to submit patch request ... but somehow heard nothing back!")
-    sys.exit(1)
-else:
-    if isinstance(patch_column_response, list):
-        for r in patch_column_response:
-            if r.status == "successful":
-                logging.info(r.result[0].response)
-            else:
-                logging.error(f"Finished with status {r.status}: {r.result}")
-    else:
-        logging.error("Unexpected result ... I don't know how to handle this ...")
-        sys.exit(1)
-
 
 # ================================
 # CREATE TABLE WITH TECHNICAL AND LOGICAL METADATA
@@ -198,6 +169,12 @@ post_column_response = alation.rdbms.post_columns(
             , column_type = "INTEGER"
             , title = "ID"
             , description = "This is the id column of the refunds table ..."
+            , index = allie.ColumnIndex(
+                isPrimaryKey = True
+                , isForeignKey = False
+                , referencedColumnId = None
+                , isOtherIndex = False
+            )
         )
     ]
 )
@@ -231,9 +208,15 @@ patch_column_response = alation.rdbms.patch_columns(
     ds_id = DATA_SOURCE_ID,
     columns = [
         allie.ColumnPatchItem(
-            id = created_column_id,
-            title = "ID",
-            description = "Updated description for the id column ..."
+            id = created_column_id
+            , title = "ID"
+            , description = "Updated description for the id column ..."
+            , index=allie.ColumnIndex(
+                isPrimaryKey=True
+                , isForeignKey=False
+                , referencedColumnId=None
+                , isOtherIndex=False
+            )
         )
     ]
 )

--- a/examples/example_rdbms.py
+++ b/examples/example_rdbms.py
@@ -119,6 +119,36 @@ else:
         sys.exit(1)
 
 # ================================
+# UPDATE COLUMN WITH PATCH
+# ================================
+
+patch_column_response = alation.rdbms.patch_columns(
+    ds_id = DATA_SOURCE_ID,
+    columns = [
+        allie.ColumnPatchItem(
+            id = created_column_id,
+            title = "ID",
+            description = "Updated description for the id column ..."
+        )
+    ]
+)
+
+if patch_column_response is None:
+    logging.error("Tried to submit patch request ... but somehow heard nothing back!")
+    sys.exit(1)
+else:
+    if isinstance(patch_column_response, list):
+        for r in patch_column_response:
+            if r.status == "successful":
+                logging.info(r.result[0].response)
+            else:
+                logging.error(f"Finished with status {r.status}: {r.result}")
+    else:
+        logging.error("Unexpected result ... I don't know how to handle this ...")
+        sys.exit(1)
+
+
+# ================================
 # CREATE TABLE WITH TECHNICAL AND LOGICAL METADATA
 # ================================
 
@@ -192,3 +222,33 @@ else:
     else:
         logging.error("Unexpected result ... I don't know how to handle this ...")
         sys.exit(1)
+
+# ================================
+# UPDATE COLUMN WITH PATCH
+# ================================
+
+patch_column_response = alation.rdbms.patch_columns(
+    ds_id = DATA_SOURCE_ID,
+    columns = [
+        allie.ColumnPatchItem(
+            id = created_column_id,
+            title = "ID",
+            description = "Updated description for the id column ..."
+        )
+    ]
+)
+
+if patch_column_response is None:
+    logging.error("Tried to submit patch request ... but somehow heard nothing back!")
+    sys.exit(1)
+else:
+    if isinstance(patch_column_response, list):
+        for r in patch_column_response:
+            if r.status == "successful":
+                logging.info(r.result[0].response)
+            else:
+                logging.error(f"Finished with status {r.status}: {r.result}")
+    else:
+        logging.error("Unexpected result ... I don't know how to handle this ...")
+        sys.exit(1)
+

--- a/tests/methods/test_rdbms.py
+++ b/tests/methods/test_rdbms.py
@@ -4,15 +4,17 @@ import requests_mock
 import unittest
 from allie_sdk.methods.rdbms import *
 
-MOCK_RDBMS = AlationRDBMS(
-    access_token='test', session=requests.session(), host='https://test.com'
-)
-
-
 class TestRDBMS(unittest.TestCase):
 
+    def setUp(self):
+        self.mock_user = AlationRDBMS(
+            access_token='test',
+            session=requests.session(),
+            host='https://test.com'
+        )
+
     @requests_mock.Mocker()
-    def test_success_get_schemas(self, m):
+    def test_success_get_schemas(self, requests_mock):
 
         mock_params = SchemaParams()
         mock_params.id.add(5)
@@ -42,26 +44,26 @@ class TestRDBMS(unittest.TestCase):
             }
         ]
         success_schemas = [Schema.from_api_response(item) for item in success_response]
-        m.register_uri('GET', '/integration/v2/schema/?id=5', json=success_response)
-        schemas = MOCK_RDBMS.get_schemas(mock_params)
+        requests_mock.register_uri('GET', '/integration/v2/schema/?id=5', json=success_response)
+        schemas = self.mock_user.get_schemas(mock_params)
 
         self.assertEqual(success_schemas, schemas)
 
     @requests_mock.Mocker()
-    def test_failed_get_schemas(self, m):
+    def test_failed_get_schemas(self, requests_mock):
 
         failed_response = {
             "detail": "Invalid query parameters: [ids]",
             "code": "400006"
         }
-        m.register_uri('GET', '/integration/v2/schema/', json=failed_response, status_code=400)
+        requests_mock.register_uri('GET', '/integration/v2/schema/', json=failed_response, status_code=400)
         
         # The method should now raise an HTTPError for non-200 status codes
         with self.assertRaises(requests.exceptions.HTTPError):
-            MOCK_RDBMS.get_schemas()
+            self.mock_user.get_schemas()
 
     @requests_mock.Mocker()
-    def test_success_post_schemas(self, m):
+    def test_success_post_schemas(self, requests_mock):
 
         mock_schema = SchemaItem()
         mock_schema.key = '1.schema.test'
@@ -86,16 +88,16 @@ class TestRDBMS(unittest.TestCase):
                 }
             ]
         }
-        m.register_uri('POST', '/integration/v2/schema/?ds_id=1', json=async_response)
-        m.register_uri('GET', '/api/v1/bulk_metadata/job/?id=1', json=job_response)
-        async_result = MOCK_RDBMS.post_schemas(1, mock_schema_list)
+        requests_mock.register_uri('POST', '/integration/v2/schema/?ds_id=1', json=async_response)
+        requests_mock.register_uri('GET', '/api/v1/bulk_metadata/job/?id=1', json=job_response)
+        async_result = self.mock_user.post_schemas(1, mock_schema_list)
 
         input_transformed = [JobDetailsRdbms(**job_response)]
         # self.assertTrue(async_result)
         self.assertEqual(input_transformed, async_result)
 
     @requests_mock.Mocker()
-    def test_failed_post_schemas(self, m):
+    def test_failed_post_schemas(self, requests_mock):
         mock_schema = SchemaItem()
         mock_schema.key = '1.schema.test'
         mock_schema.title = 'Test Title'
@@ -113,18 +115,18 @@ class TestRDBMS(unittest.TestCase):
             ],
             "code": "400010"
         }
-        m.register_uri('POST', '/integration/v2/schema/?ds_id=1',
+        requests_mock.register_uri('POST', '/integration/v2/schema/?ds_id=1',
                       json=failed_response, status_code=400)
         
         # Now we expect an HTTPError to be raised
         with self.assertRaises(requests.exceptions.HTTPError) as context:
-            MOCK_RDBMS.post_schemas(ds_id=1, schemas=mock_schema_list)
+            self.mock_user.post_schemas(ds_id=1, schemas=mock_schema_list)
         
         # Verify the error response contains expected information
         self.assertEqual(context.exception.response.status_code, 400)
 
     @requests_mock.Mocker()
-    def test_success_get_tables(self, m):
+    def test_success_get_tables(self, requests_mock):
 
         mock_params = TableParams()
         mock_params.id.add(93)
@@ -160,26 +162,26 @@ class TestRDBMS(unittest.TestCase):
             }
         ]
         success_tables = [Table.from_api_response(item) for item in success_response]
-        m.register_uri('GET', '/integration/v2/table/?id=93', json=success_response)
-        tables = MOCK_RDBMS.get_tables(mock_params)
+        requests_mock.register_uri('GET', '/integration/v2/table/?id=93', json=success_response)
+        tables = self.mock_user.get_tables(mock_params)
 
         self.assertEqual(success_tables, tables)
 
     @requests_mock.Mocker()
-    def test_failed_get_tables(self, m):
+    def test_failed_get_tables(self, requests_mock):
 
         failed_response = {
             "detail": "Invalid query parameters: [ids]",
             "code": "400006"
         }
-        m.register_uri('GET', '/integration/v2/table/', json=failed_response, status_code=400)
+        requests_mock.register_uri('GET', '/integration/v2/table/', json=failed_response, status_code=400)
         
         # The method should now raise an HTTPError for non-200 status codes
         with self.assertRaises(requests.exceptions.HTTPError):
-            MOCK_RDBMS.get_tables()
+            self.mock_user.get_tables()
 
     @requests_mock.Mocker()
-    def test_success_post_tables(self, m):
+    def test_success_post_tables(self, requests_mock):
 
         mock_table = TableItem()
         mock_table.key = '1.schema.test'
@@ -212,16 +214,16 @@ class TestRDBMS(unittest.TestCase):
             ]
         }
 
-        m.register_uri('POST', '/integration/v2/table/?ds_id=1', json=async_response)
-        m.register_uri('GET', '/api/v1/bulk_metadata/job/?id=1', json=job_response)
-        async_result = MOCK_RDBMS.post_tables(1, mock_table_list)
+        requests_mock.register_uri('POST', '/integration/v2/table/?ds_id=1', json=async_response)
+        requests_mock.register_uri('GET', '/api/v1/bulk_metadata/job/?id=1', json=job_response)
+        async_result = self.mock_user.post_tables(1, mock_table_list)
 
         input_transformed = [JobDetailsRdbms(**job_response)]
         # self.assertTrue(async_result)
         self.assertEqual(input_transformed, async_result)
 
     @requests_mock.Mocker()
-    def test_failed_post_tables(self, m):
+    def test_failed_post_tables(self, requests_mock):
         mock_table = TableItem()
         mock_table.key = '1.schema.test'
         mock_table.title = 'Test Title'
@@ -239,18 +241,18 @@ class TestRDBMS(unittest.TestCase):
             ],
             "code": "400010"
         }
-        m.register_uri('POST', '/integration/v2/table/?ds_id=1',
+        requests_mock.register_uri('POST', '/integration/v2/table/?ds_id=1',
                       json=failed_response, status_code=400)
         
         # Now we expect an HTTPError to be raised
         with self.assertRaises(requests.exceptions.HTTPError) as context:
-            MOCK_RDBMS.post_tables(ds_id=1, tables=mock_table_list)
+            self.mock_user.post_tables(ds_id=1, tables=mock_table_list)
         
         # Verify the error response contains expected information
         self.assertEqual(context.exception.response.status_code, 400)
 
     @requests_mock.Mocker()
-    def test_success_get_columns(self, m):
+    def test_success_get_columns(self, requests_mock):
 
         mock_params = ColumnParams()
         mock_params.id.add(1613)
@@ -302,62 +304,111 @@ class TestRDBMS(unittest.TestCase):
             }
         ]
         success_columns = [Column.from_api_response(item) for item in success_response]
-        m.register_uri('GET', '/integration/v2/column/?id=1613', json=success_response)
-        columns = MOCK_RDBMS.get_columns(mock_params)
+        requests_mock.register_uri('GET', '/integration/v2/column/?id=1613', json=success_response)
+        columns = self.mock_user.get_columns(mock_params)
 
         self.assertEqual(success_columns, columns)
 
     @requests_mock.Mocker()
-    def test_failed_get_columns(self, m):
+    def test_failed_get_columns(self, requests_mock):
 
         failed_response = {
             "detail": "Invalid query parameters: [ids]",
             "code": "400006"
         }
-        m.register_uri('GET', '/integration/v2/column/', json=failed_response, status_code=400)
+        requests_mock.register_uri('GET', '/integration/v2/column/', json=failed_response, status_code=400)
         
         # The method should now raise an HTTPError for non-200 status codes
         with self.assertRaises(requests.exceptions.HTTPError):
-            MOCK_RDBMS.get_columns()
+            self.mock_user.get_columns()
 
     @requests_mock.Mocker()
-    def test_success_post_columns(self, m):
+    def test_success_post_columns(self, requests_mock):
 
-        mock_column = ColumnItem()
-        mock_column.key = '1.schema.test'
-        mock_column.title = 'Test Title'
-        mock_column.description = 'Test Description'
-        mock_column.column_type = 'VARCHAR'
-        mock_column_list = [mock_column]
+        # --- PREPARE THE TEST SETUP --- #
 
+        # payload for the main request
+        columns = [
+            ColumnItem(
+                key=f"1.ORDERS.refunds.id"
+                , column_type="INTEGER"
+                , title="ID"
+                , description="This is the id column of the refunds table ..."
+                , index=ColumnIndex(
+                    isPrimaryKey=True
+                    , isForeignKey=False
+                    , referencedColumnId=None
+                    , isOtherIndex=False
+                )
+            )
+        ]
+
+
+        # What does the response look like for the main request?
         async_response = {
-            "job_id": 1
+            "job_id": 27809
         }
-        job_response = {
+
+        # Override the main API call
+        requests_mock.register_uri(
+            method='POST',
+            url='/integration/v2/column/?ds_id=1',
+            json=async_response,
+            status_code=202
+        )
+
+        # What does the response look like for the Job?
+        job_api_response = {
             "status": "successful",
             "msg": "Job finished in 6.076855 seconds at 2023-11-30 16:21:37.152796+00:00",
             "result": [
                 {
-                    "response": "Upserted 2 attribute objects.",
+                    "response": "Upserted 1 attribute objects.",
                     "mapping": [
-                        {"id": 17634, "key": "9.sales.orders.id"},
-                        {"id": 17646, "key": "9.sales.orders.discount"},
+                        {"id": 17634, "key": "1.ORDERS.refunds.id"}
                     ],
                     "errors": []
                 }
             ]
         }
 
-        m.register_uri('POST', '/integration/v2/column/?ds_id=1', json=async_response)
-        m.register_uri('GET', '/api/v1/bulk_metadata/job/?id=1', json=job_response)
-        async_result = MOCK_RDBMS.post_columns(1, mock_column_list)
+        # Override the job API call
+        # Note: The id in the job URL corresponds to the task id in document_api_response defined above
+        requests_mock.register_uri(
+            method='GET'
+            , url='/api/v1/bulk_metadata/job/?id=27809'
+            , json=job_api_response
+        )
 
-        input_transformed = [JobDetailsRdbms(**job_response)]
+        # --- TEST THE FUNCTION --- #
+        async_result = self.mock_user.post_columns(
+            ds_id = 1
+            , columns = columns
+        )
+
+        expected_result = [
+            JobDetailsRdbms(
+                status = "successful"
+                , msg = "Job finished in 6.076855 seconds at 2023-11-30 16:21:37.152796+00:00"
+                , result = [
+                    JobDetailsRdbmsResult(
+                        response = "Upserted 1 attribute objects."
+                        , mapping = [
+                            JobDetailsRdbmsResultMapping(
+                                id = 17634
+                                , key = "1.ORDERS.refunds.id"
+                            )
+                        ]
+                        , errors = []
+                    )
+                ]
+            )
+        ]
         # self.assertTrue(async_result)
-        self.assertEqual(input_transformed, async_result)
+        self.assertEqual(expected_result, async_result)
 
     @requests_mock.Mocker()
-    def test_failed_post_columns(self, m):
+    def test_failed_post_columns(self, requests_mock):
         mock_column = ColumnItem()
         mock_column.key = '1.schema.test'
         mock_column.title = 'Test Title'
@@ -376,51 +427,102 @@ class TestRDBMS(unittest.TestCase):
             ],
             "code": "400010"
         }
-        m.register_uri('POST', '/integration/v2/column/?ds_id=1',
+        requests_mock.register_uri('POST', '/integration/v2/column/?ds_id=1',
                       json=failed_response, status_code=400)
         
         # Now we expect an HTTPError to be raised
         with self.assertRaises(requests.exceptions.HTTPError) as context:
-            MOCK_RDBMS.post_columns(ds_id=1, columns=mock_column_list)
+            self.mock_user.post_columns(ds_id=1, columns=mock_column_list)
         
         # Verify the error response contains expected information
         self.assertEqual(context.exception.response.status_code, 400)
 
     @requests_mock.Mocker()
-    def test_success_patch_columns(self, m):
+    def test_success_patch_column(self, requests_mock):
 
-        mock_column = ColumnPatchItem(
-            id=1,
-            title='Updated Title'
-        )
-        mock_column_list = [mock_column]
+        # --- PREPARE THE TEST SETUP --- #
 
+        # payload for the main request
+        columns = [
+            ColumnPatchItem(
+                id=1
+                , title='Updated Title'
+                , description="This is the id column of the refunds table ..."
+                , index=ColumnIndex(
+                    isPrimaryKey=True
+                    , isForeignKey=False
+                    , referencedColumnId=None
+                    , isOtherIndex=False
+                )
+            )
+        ]
+
+        # What does the response look like for the main request?
         async_response = {
-            "job_id": 1
+            "job_id": 27809
         }
-        job_response = {
+
+        # Override the main API call
+        requests_mock.register_uri(
+            method='PATCH',
+            url='/integration/v2/column/?ds_id=1',
+            json=async_response,
+            status_code=202
+        )
+
+        # What does the response look like for the Job?
+        job_api_response = {
             "status": "successful",
-            "msg": "Job finished in 1 second",
+            "msg": "Job finished in 6.076855 seconds at 2023-11-30 16:21:37.152796+00:00",
             "result": [
                 {
                     "response": "Updated 1 attribute objects.",
                     "mapping": [
-                        {"id": 1, "key": "9.sales.orders.id"}
+                        {"id": 1, "key": "1.ORDERS.refunds.id"}
                     ],
                     "errors": []
                 }
             ]
         }
 
-        m.register_uri('PATCH', '/integration/v2/column/?ds_id=1', json=async_response)
-        m.register_uri('GET', '/api/v1/bulk_metadata/job/?id=1', json=job_response)
-        async_result = MOCK_RDBMS.patch_columns(1, mock_column_list)
+        # Override the job API call
+        # Note: The id in the job URL corresponds to the task id in document_api_response defined above
+        requests_mock.register_uri(
+            method='GET'
+            , url='/api/v1/bulk_metadata/job/?id=27809'
+            , json=job_api_response
+        )
 
-        input_transformed = [JobDetailsRdbms(**job_response)]
-        self.assertEqual(input_transformed, async_result)
+        # --- TEST THE FUNCTION --- #
+
+        async_result = self.mock_user.patch_columns(
+            ds_id=1
+            , columns = columns
+        )
+
+        expected_result = [
+            JobDetailsRdbms(
+                status="successful"
+                , msg="Job finished in 6.076855 seconds at 2023-11-30 16:21:37.152796+00:00"
+                , result=[
+                    JobDetailsRdbmsResult(
+                        response="Updated 1 attribute objects."
+                        , mapping=[
+                            JobDetailsRdbmsResultMapping(
+                                id=1
+                                , key="1.ORDERS.refunds.id"
+                            )
+                        ]
+                        , errors=[]
+                    )
+                ]
+            )
+        ]
+
+        self.assertEqual(expected_result, async_result)
 
     @requests_mock.Mocker()
-    def test_failed_patch_columns(self, m):
+    def test_failed_patch_columns(self, requests_mock):
         mock_column = ColumnPatchItem(id=1)
         mock_column_list = [mock_column]
 
@@ -436,11 +538,11 @@ class TestRDBMS(unittest.TestCase):
             "code": "400010",
         }
 
-        m.register_uri('PATCH', '/integration/v2/column/?ds_id=1',
+        requests_mock.register_uri('PATCH', '/integration/v2/column/?ds_id=1',
                       json=failed_response, status_code=400)
 
         with self.assertRaises(requests.exceptions.HTTPError) as context:
-            MOCK_RDBMS.patch_columns(ds_id=1, columns=mock_column_list)
+            self.mock_user.patch_columns(ds_id=1, columns=mock_column_list)
 
         self.assertEqual(context.exception.response.status_code, 400)
 

--- a/tests/models/test_rdbms_model.py
+++ b/tests/models/test_rdbms_model.py
@@ -338,6 +338,50 @@ class TestRDBMSModels(unittest.TestCase):
 
         self.assertRaises(InvalidPostBody, lambda: mock_column.generate_api_post_payload())
 
+    def test_column_patch_item_payload(self):
+        mock_column = ColumnPatchItem(
+            id=1,
+            title="Customer Name",
+            description="<p>This is the customer name</p>",
+            custom_fields=[
+                CustomFieldValueItem(field_id=1, value=CustomFieldStringValueItem(value="Testing")),
+                CustomFieldValueItem(field_id=2, value=[CustomFieldDictValueItem(otype='Table', oid=5)])
+            ],
+            column_comment="This is a comment",
+            nullable=False,
+            position=7,
+            index=ColumnIndex(
+                isPrimaryKey=False,
+                isForeignKey=True,
+                isOtherIndex=False,
+                referencedColumnId="1.Test.Table"
+            )
+        )
+        expected_payload = {
+            "id": 1,
+            "title": "Customer Name",
+            "description": "<p>This is the customer name</p>",
+            "column_comment": "This is a comment",
+            "nullable": False,
+            "position": 7,
+            "index": {"isPrimaryKey": False, "isForeignKey": True, "isOtherIndex": False,
+                      "referencedColumnId": "1.Test.Table"},
+            "custom_fields": [
+                {'field_id': 1, 'value': 'Testing'},
+                {'field_id': 2, 'value': [{'otype': 'table', 'oid': 5}]}
+            ]
+        }
+
+        self.assertEqual(mock_column.generate_api_patch_payload(), expected_payload)
+
+    def test_column_patch_item_exception_missing_id(self):
+        mock_column = ColumnPatchItem(
+            title="Customer Name",
+            description="<p>This is the customer name</p>"
+        )
+
+        self.assertRaises(InvalidPostBody, lambda: mock_column.generate_api_patch_payload())
+
     def test_base_rdbms_custom_field_parsing(self):
 
         mock_base = BaseRDBMS(

--- a/tests/models/test_rdbms_model.py
+++ b/tests/models/test_rdbms_model.py
@@ -364,8 +364,12 @@ class TestRDBMSModels(unittest.TestCase):
             "column_comment": "This is a comment",
             "nullable": False,
             "position": 7,
-            "index": {"isPrimaryKey": False, "isForeignKey": True, "isOtherIndex": False,
-                      "referencedColumnId": "1.Test.Table"},
+            "index": {
+                "isPrimaryKey": False
+                , "isForeignKey": True
+                , "isOtherIndex": False
+                , "referencedColumnId": "1.Test.Table"
+            },
             "custom_fields": [
                 {'field_id': 1, 'value': 'Testing'},
                 {'field_id': 2, 'value': [{'otype': 'table', 'oid': 5}]}


### PR DESCRIPTION
## Summary
- support patching columns via new ColumnPatchItem model and rdbms.patch_columns method
- document column patch usage in RDBMS example
- test column patch payload and patch_columns workflow

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests_mock')*
- `pytest tests/models/test_rdbms_model.py::TestRDBMSModels::test_column_patch_item_payload -q`


------
https://chatgpt.com/codex/tasks/task_b_68c43eb22730832ea13789a4faaa6f44