### PR TITLE
Add schema patch support to RDBMS client

### DIFF
--- a/allie_sdk/__init__.py
+++ b/allie_sdk/__init__.py
@@ -88,6 +88,7 @@ from .models import (
     RefreshToken,
     Schema,
     SchemaItem,
+    SchemaPatchItem,
     SchemaParams,
     Table,
     TableItem,

--- a/allie_sdk/methods/rdbms.py
+++ b/allie_sdk/methods/rdbms.py
@@ -6,7 +6,7 @@ import requests
 from ..core.async_handler import AsyncHandler
 from ..core.custom_exceptions import validate_query_params, validate_rest_payload
 from ..models.rdbms_model import (
-    Schema, SchemaItem, SchemaParams,
+    Schema, SchemaItem, SchemaParams, SchemaPatchItem,
     Table, TableItem, TableParams,
     Column, ColumnItem, ColumnIndex, ColumnPatchItem, ColumnParams
 )
@@ -68,6 +68,28 @@ class AlationRDBMS(AsyncHandler):
         validate_rest_payload(schemas, (SchemaItem,))
         payload = [item.generate_api_post_payload() for item in schemas]
         async_results = self.async_post(f'/integration/v2/schema/?ds_id={ds_id}', payload)
+
+        if async_results:
+            return [JobDetailsRdbms.from_api_response(item) for item in async_results]
+        return []
+
+    def patch_schemas(self, ds_id: int, schemas: list[SchemaPatchItem]) -> list[JobDetailsRdbms]:
+        """Patch (Update) Alation Schema Objects.
+
+        Args:
+            ds_id (int): ID of the Alation Schemas' Parent Datasource.
+            schemas (list[SchemaPatchItem]): Alation Schemas to be updated.
+
+        Returns:
+            list[JobDetailsRdbms]: result of the job
+
+        Raises:
+            requests.HTTPError: If the API returns a non-success status code.
+        """
+        item: SchemaPatchItem
+        validate_rest_payload(schemas, (SchemaPatchItem,))
+        payload = [item.generate_api_patch_payload() for item in schemas]
+        async_results = self.async_patch(f'/integration/v2/schema/?ds_id={ds_id}', payload)
 
         if async_results:
             return [JobDetailsRdbms.from_api_response(item) for item in async_results]

--- a/allie_sdk/models/rdbms_model.py
+++ b/allie_sdk/models/rdbms_model.py
@@ -79,6 +79,27 @@ class SchemaItem(BaseRDBMSItem):
 
         return payload
 
+
+@dataclass
+class SchemaPatchItem(BaseRDBMSItem):
+    id: int = field(default=None)
+    db_comment: str = field(default=None)
+
+    def generate_api_patch_payload(self):
+        if self.id is None:
+            raise InvalidPostBody("'id' is a required field for Schema PATCH payload body")
+        payload = {'id': self.id}
+        if self.title:
+            payload['title'] = self.title
+        if self.description:
+            payload['description'] = self.description
+        if self.db_comment:
+            payload['db_comment'] = self.db_comment
+        if self.custom_fields:
+            payload['custom_fields'] = self._create_fields_payload()
+
+        return payload
+
 @dataclass
 class SchemaParams(BaseRDBMSParams):
     pass

--- a/docs/pages/reference/RDBMS.md
+++ b/docs/pages/reference/RDBMS.md
@@ -78,7 +78,20 @@ Attributes:
 
 | Name         | Type                  | Description                                                  |
 |--------------|-----------------------|--------------------------------------------------------------|
-| db_comment   | str         | Comments on the schema from the data source. Defaults to empty text if not passed in the request. | 
+| db_comment   | str         | Comments on the schema from the data source. Defaults to empty text if not passed in the request. |
+
+### SchemaPatchItem
+Python object used to update an existing `Schema` in Alation and passed in the parameter `schemas` as a list in the function `patch_schemas`.
+
+Attributes:
+
+| Name         | Required | Type | Description |
+|--------------|:--------:|------|-------------|
+| id           | TRUE     | int  | Identifier of the schema to be updated. |
+| title        | FALSE    | str  | The title of the schema. |
+| description  | FALSE    | str  | Description of the schema. |
+| db_comment   | FALSE    | str  | Comments on the schema from the data source. |
+| custom_fields | FALSE   | list | A list of `CustomFieldValueItem` objects containing custom field information relative to the schema. |
 
 ### SchemaParams
 Optional item used to filter the response of the returned data from the function `get_schemas`.
@@ -247,6 +260,24 @@ Args:
 
 Returns:
 * list of job details
+
+### patch_schemas
+
+```python
+patch_schemas(ds_id: int, schemas: list[SchemaPatchItem]) -> list[allie_sdk.models.job_model.JobDetailsRdbms]
+```
+
+Patch (Update) Alation Schema Objects.
+
+Args:
+   - `ds_id` (int): ID of the Alation Schemas' Parent Datasource.
+   - `schemas` (list[SchemaPatchItem]): Alation Schemas to be updated.
+
+Returns:
+   - `list[JobDetailsRdbms]`: result of the job
+
+Raises:
+   - `requests.HTTPError`: If the API returns a non-success status code.
 
 ### get_tables
 

--- a/tests/methods/test_rdbms.py
+++ b/tests/methods/test_rdbms.py
@@ -121,8 +121,102 @@ class TestRDBMS(unittest.TestCase):
         # Now we expect an HTTPError to be raised
         with self.assertRaises(requests.exceptions.HTTPError) as context:
             self.mock_user.post_schemas(ds_id=1, schemas=mock_schema_list)
-        
+
         # Verify the error response contains expected information
+        self.assertEqual(context.exception.response.status_code, 400)
+
+    @requests_mock.Mocker()
+    def test_success_patch_schemas(self, requests_mock):
+
+        schemas = [
+            SchemaPatchItem(
+                id=1,
+                title='Updated Schema Title',
+                description='Updated description for schema',
+                db_comment='New database comment'
+            )
+        ]
+
+        async_response = {
+            "job_id": 27808
+        }
+
+        requests_mock.register_uri(
+            method='PATCH',
+            url='/integration/v2/schema/?ds_id=1',
+            json=async_response,
+            status_code=202
+        )
+
+        job_api_response = {
+            "status": "successful",
+            "msg": "Job finished in 5.01234 seconds at 2023-11-30 16:15:20.000000+00:00",
+            "result": [
+                {
+                    "response": "Updated 1 schema objects.",
+                    "mapping": [
+                        {"id": 1, "key": "1.ORDERS"}
+                    ],
+                    "errors": []
+                }
+            ]
+        }
+
+        requests_mock.register_uri(
+            method='GET',
+            url='/api/v1/bulk_metadata/job/?id=27808',
+            json=job_api_response
+        )
+
+        async_result = self.mock_user.patch_schemas(
+            ds_id=1,
+            schemas=schemas
+        )
+
+        expected_result = [
+            JobDetailsRdbms(
+                status="successful",
+                msg="Job finished in 5.01234 seconds at 2023-11-30 16:15:20.000000+00:00",
+                result=[
+                    JobDetailsRdbmsResult(
+                        response="Updated 1 schema objects.",
+                        mapping=[
+                            JobDetailsRdbmsResultMapping(
+                                id=1,
+                                key="1.ORDERS"
+                            )
+                        ],
+                        errors=[]
+                    )
+                ]
+            )
+        ]
+
+        self.assertEqual(expected_result, async_result)
+
+    @requests_mock.Mocker()
+    def test_failed_patch_schemas(self, requests_mock):
+        mock_schema = SchemaPatchItem(id=1)
+        mock_schema_list = [mock_schema]
+
+        failed_response = {
+            "detail": "Incorrect input data. Please fix the errors and post the data.",
+            "errors": [
+                {
+                    "id": [
+                        "400068: id is a required input"
+                    ]
+                }
+            ],
+            "code": "400010"
+        }
+
+        requests_mock.register_uri('PATCH', '/integration/v2/schema/?ds_id=1',
+                      json=failed_response, status_code=400)
+
+        with self.assertRaises(requests.exceptions.HTTPError) as context:
+            self.mock_user.patch_schemas(ds_id=1, schemas=mock_schema_list)
+
         self.assertEqual(context.exception.response.status_code, 400)
 
     @requests_mock.Mocker()


### PR DESCRIPTION
## Summary
- add a `SchemaPatchItem` model for building schema PATCH payloads
- expose a new `patch_schemas` helper on the RDBMS client
- document the schema patch workflow and cover it with unit tests

## Testing
- `pytest tests/methods/test_rdbms.py` *(fails: ModuleNotFoundError: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_b_68cbced3ef50832e8d902e99c21b824e