### PR TITLE
AL-247072 chore: enable renovate automerge and align with team pattern

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,62 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 0,6,12,18 * * *"
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Dry-run mode (extract/lookup/full). Leave empty for real run."
+        required: false
+        default: ""
+        type: choice
+        options:
+          - ""
+          - extract
+          - lookup
+          - full
+      logLevel:
+        description: "Log level"
+        required: false
+        default: "debug"
+        type: choice
+        options:
+          - debug
+          - info
+          - warn
+          - error
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3.0.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.ALAVATE_APP_ID }}
+          private-key: ${{ secrets.ALAVATE_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74  # v46.1.9
+        env:
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
+          LOG_LEVEL: ${{ github.event.inputs.logLevel || 'debug' }}
+          RENOVATE_PLATFORM: "github"
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun || '' }}
+        with:
+          configurationFile: renovate.json
+          env-regex: "^(?:RENOVATE_\\w+|LOG_LEVEL)$"

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "enabledManagers": ["pip_requirements", "poetry", "pep621", "github-actions"],
+  "enabledManagers": ["pep621", "github-actions"],
   "baseBranches": ["main"],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
@@ -32,7 +32,7 @@
   "packageRules": [
     {
       "description": "🐍 Python dependencies - PATCH updates (automerge)",
-      "matchManagers": ["pip_requirements", "poetry", "pep621"],
+      "matchManagers": ["pep621"],
       "matchUpdateTypes": ["patch"],
       "groupName": "python-patch-updates",
       "semanticCommitType": "fix",
@@ -43,7 +43,7 @@
     },
     {
       "description": "🐍 Python dependencies - MINOR updates (automerge)",
-      "matchManagers": ["pip_requirements", "poetry", "pep621"],
+      "matchManagers": ["pep621"],
       "matchUpdateTypes": ["minor"],
       "groupName": "python-minor-updates",
       "semanticCommitType": "feat",
@@ -104,7 +104,7 @@
     },
     {
       "description": "🚫 DISABLED: Internal Alation Python packages",
-      "matchManagers": ["pip_requirements", "poetry", "pep621"],
+      "matchManagers": ["pep621"],
       "matchPackageNames": ["alation-mt-s3", "asimov", "cmsclient", "secrets-store-env"],
       "enabled": false
     },
@@ -115,8 +115,6 @@
       "enabled": false
     }
   ],
-  "pip_requirements": { "enabled": true, "fileMatch": ["(^|/)requirements.*\\.txt$"] },
-  "poetry": { "enabled": true },
   "pep621": { "enabled": true },
   "ignoreDeps": [],
   "ignorePaths": ["**/vendor/**"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["pip_requirements", "poetry", "pep621", "github-actions"],
+  "baseBranches": ["main"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
+  "platformAutomerge": true,
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "reviewers": [
+    "jonlanham-alation",
+    "diethard-at-alation",
+    "ignaszewskir",
+    "cory-alation"
+  ],
+  "commitMessagePrefix": "chore:",
+  "commitMessageAction": "update",
+  "prHeader": "## 📝 Summary",
+  "prFooter": "## 💡 Solution\n\nUpdate {{{depName}}} from {{currentVersion}} to {{newVersion}}",
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["dependencies", "renovate", "security"],
+    "semanticCommitType": "fix",
+    "semanticCommitScope": "security",
+    "schedule": []
+  },
+  "osvVulnerabilityAlerts": true,
+  "recreateWhen": "always",
+  "labels": ["dependencies", "renovate"],
+  "packageRules": [
+    {
+      "description": "🐍 Python dependencies - PATCH updates (automerge)",
+      "matchManagers": ["pip_requirements", "poetry", "pep621"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "python-patch-updates",
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "python",
+      "automerge": true,
+      "labels": ["dependencies", "renovate", "python", "patch", "automerge"],
+      "prPriority": 40
+    },
+    {
+      "description": "🐍 Python dependencies - MINOR updates (automerge)",
+      "matchManagers": ["pip_requirements", "poetry", "pep621"],
+      "matchUpdateTypes": ["minor"],
+      "groupName": "python-minor-updates",
+      "semanticCommitType": "feat",
+      "semanticCommitScope": "python",
+      "automerge": true,
+      "labels": ["dependencies", "renovate", "python", "minor", "automerge"],
+      "prPriority": 30
+    },
+    {
+      "description": "⚙️ GitHub Actions - PATCH updates (automerge)",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch"],
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "actions",
+      "automerge": true,
+      "labels": ["dependencies", "renovate", "github-actions", "patch", "automerge"],
+      "prPriority": 40
+    },
+    {
+      "description": "⚙️ GitHub Actions - MINOR updates (automerge)",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor"],
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "actions",
+      "automerge": true,
+      "labels": ["dependencies", "renovate", "github-actions", "minor", "automerge"],
+      "prPriority": 30
+    },
+    {
+      "description": "🚫 DISABLED: All non-security MAJOR updates (temporarily blocked). Placed before the security rules so those still open (last-rule-wins).",
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "🔐 Security PATCH vulnerability fixes (automerge, highest priority). Uses the v42 isVulnerabilityAlert matcher at the top level — nesting packageRules inside vulnerabilityAlerts is silently ignored by Renovate's force/applyPackageRules path.",
+      "matchUpdateTypes": ["patch"],
+      "isVulnerabilityAlert": true,
+      "automerge": true,
+      "prPriority": 99,
+      "labels": ["dependencies", "renovate", "security", "automerge"]
+    },
+    {
+      "description": "🔐 Security MINOR vulnerability fixes (automerge).",
+      "matchUpdateTypes": ["minor"],
+      "isVulnerabilityAlert": true,
+      "automerge": true,
+      "prPriority": 95,
+      "labels": ["dependencies", "renovate", "security", "automerge"]
+    },
+    {
+      "description": "🔐 Security MAJOR vulnerability fixes (manual review). Placed after the major catch-all so security majors re-open for manual review (last-rule-wins); enabled:true overrides the catch-all's enabled:false.",
+      "matchUpdateTypes": ["major"],
+      "isVulnerabilityAlert": true,
+      "enabled": true,
+      "automerge": false,
+      "prPriority": 90,
+      "labels": ["dependencies", "renovate", "security"]
+    },
+    {
+      "description": "🚫 DISABLED: Internal Alation Python packages",
+      "matchManagers": ["pip_requirements", "poetry", "pep621"],
+      "matchPackageNames": ["alation-mt-s3", "asimov", "cmsclient", "secrets-store-env"],
+      "enabled": false
+    },
+    {
+      "description": "🚫 DISABLED: Internal Alation GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["/^alation/.*/", "/^Alation/.*/"],
+      "enabled": false
+    }
+  ],
+  "pip_requirements": { "enabled": true, "fileMatch": ["(^|/)requirements.*\\.txt$"] },
+  "poetry": { "enabled": true },
+  "pep621": { "enabled": true },
+  "ignoreDeps": [],
+  "ignorePaths": ["**/vendor/**"]
+}


### PR DESCRIPTION
## 📝 Summary

Enables hands-off dependency updates for `Allie-SDK` by **scaffolding** the Renovate configuration (setup mode — no prior config) with the canonical Alation pattern first merged in `oauth_token_service` (AL-246771) and adopted by `alation_analytics` and `alation_connector_manager`.

Jira: AL-247072

### What changes

**Workflow (`.github/workflows/renovate.yaml`):**
- Created from template — runs every 6h (`0 0,6,12,18 * * *`) via the `ALAVATE` GitHub App, with SHA-pinned actions. Python-only env (no Go `GOPROXY`/Docker host-rules needed).

**Config (`renovate.json`):**
- Top-level `platformAutomerge: true`, `automergeType: pr`, `automergeStrategy: squash` (squash is allowed on this repo: `allow_squash_merge=true`) so all rules inherit the auto-merge contract
- Security auto-merge via top-level `isVulnerabilityAlert` packageRules — security PATCH (prPriority 99) and MINOR (95) auto-merge; security MAJOR (90) stays manual (`enabled: true`, placed after the major catch-all). `vulnerabilityAlerts` itself stays minimal — nesting `packageRules` inside it is silently ignored by Renovate v42
- `{matchUpdateTypes: ["major"], enabled: false}` catch-all so non-security major bumps don't open noisy PRs (security majors still do)
- Per-manager rule pairs (`pep621` for `pyproject.toml` deps + `github-actions`, each × patch/minor) with scoped semantic commits and per-language labels
- Disabled-internal carve-outs for Alation Python packages and Alation GitHub Actions
- `recreateWhen: always`; `prConcurrentLimit: 10`, `prHourlyLimit: 0`

`enabledManagers` is Python/uv-flavored: `pep621` covers `pyproject.toml` deps. There is no `requirements.txt`, no Dockerfile, and no Go module in this repo, so the Go/Docker rules and the `base_ubi8` carve-out from the Go template are omitted.

### Why

| Before | After |
|---|---|
| No dependency automation at all | Patch/minor + security patch/minor auto-merge after CI |
| Manual dependency bumps | Major bumps don't create PRs (security majors still do) |
| No Renovate | Aligned with `oauth_token_service`, `alation_analytics`, `alation_connector_manager` |

### Pre-merge verification

- ✅ `renovate-config-validator`: validated successfully against 1 file (only the benign `fileMatch`→`managerFilePatterns` config-migration warning; no errors)
- Reference: oauth_token_service PR #200 (https://github.com/Alation/oauth_token_service/pull/200)

### ⚠️ Follow-up required for auto-merge to actually fire

`Allie-SDK`'s `main` branch is **octoinfra-managed** (shard `repositories-011`) with **classic branch protection** requiring `run_unit_testing` **+ 1 approving review**, `enforce_admins=true`, and **no Renovate bypass actor**. CI is properly gated, but GitHub-native auto-merge will queue PRs and **never merge them** until the review requirement is bypassable by the `ALAVATE` app. That requires a separate **octoinfra Terraform PR** migrating the classic `branch_protections` block to a `ruleset` with the `ALAVATE` app as a `bypass_actor` (keeping `run_unit_testing` required and review enforced for human PRs). Tracked separately; this config PR is safe to merge independently.

